### PR TITLE
[BUGFIX] Handle customer deletion errors

### DIFF
--- a/src/app/code/community/Rack/SelfDelete/controllers/CustomerController.php
+++ b/src/app/code/community/Rack/SelfDelete/controllers/CustomerController.php
@@ -20,16 +20,21 @@ class Rack_SelfDelete_CustomerController extends Mage_Core_Controller_Front_Acti
         if (!$_customer->validatePassword($_post['password'])) {
             $this->_getSession()->addError(Mage::helper('selfdelete')->__('Password is incorrect.'));
             $this->_redirect('*/*/');
-        } else {
-            Mage::register('isSecureArea', true);
-            if($_customer->delete()) {
-                $this->_redirect('*/*/success');
-            } else {
-                $this->_getSession()->addError(Mage::helper('selfdelete')->__('Unable to delete your account'));
-                $this->_redirect('*/*/');
-            }
+            return;
         }
-        return;
+        try {
+            Mage::register('isSecureArea', true);
+            $_customer->delete();
+            Mage::unregister('isSecureArea');
+            $this->_redirect('*/*/success');
+            return;
+        } catch (Exception $e) {
+            Mage::unregister('isSecureArea');
+            Mage::logException($e);
+            $this->_getSession()->addError(Mage::helper('selfdelete')->__('Unable to delete your account'));
+            $this->_redirect('*/*/');
+            return;
+        }
     }
     
     public function successAction() 


### PR DESCRIPTION
Previously, it was assumed that a customer deletion could fail by means of a falsy return value of the method `Mage_Core_Model_Abstract::delete`; this is not possible since this method either returns `$this` or raises an exception.

In this changeset, fail by falsy return value has been removed, and error handling is added for the case an exception is raised.

Also, the `isSecureArea` registry setting has been cleared right after the deletion operation has succeed or failed.
