### PR TITLE
[CLEANUP] Remove unused default option `candeletecustomer`

### DIFF
--- a/src/app/code/community/Rack/SelfDelete/etc/config.xml
+++ b/src/app/code/community/Rack/SelfDelete/etc/config.xml
@@ -104,7 +104,6 @@
   <default>
       <selfdelete>
           <selfdelete>
-              <candeletecustomer>false</candeletecustomer>
               <candeleteorder>false</candeleteorder>
           </selfdelete>
       </selfdelete>


### PR DESCRIPTION
The default option `candeletecustomer` suggests that the customer deletion functionality is disabled by default, but this is not the case since the option is never used.
