### PR TITLE
[TASK] Sync names of classes and files

### DIFF
--- a/src/app/code/community/Rack/SelfDelete/Model/Session.php
+++ b/src/app/code/community/Rack/SelfDelete/Model/Session.php
@@ -1,4 +1,4 @@
 <?php
-class Rack_Selfdelete_Model_Session extends Mage_Core_Model_Session {
+class Rack_SelfDelete_Model_Session extends Mage_Core_Model_Session {
 
 }

--- a/src/app/code/community/Rack/SelfDelete/controllers/OrderController.php
+++ b/src/app/code/community/Rack/SelfDelete/controllers/OrderController.php
@@ -1,5 +1,5 @@
 <?php
-class Rack_Selfdelete_OrderController extends Mage_Core_Controller_Front_Action {
+class Rack_SelfDelete_OrderController extends Mage_Core_Controller_Front_Action {
 
 
     public function cancelAction() 


### PR DESCRIPTION
There were to files in which the class names had different casing than the file names.

Although it does work (class names in PHP are case insensitive), it is not consistent with the file names and with other class names.
